### PR TITLE
Run PR checks for PRs into any branch

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,9 +2,6 @@ name: PR Checks
 
 on:
   pull_request:
-    branches:
-      - main
-      - dev/development2026Spring
 
 jobs:
   check-requirements:


### PR DESCRIPTION
Drop the branches filter so the workflow runs for PRs regardless of base branch, not only main and dev/development2026Spring.