### PR TITLE
Stardist test fix

### DIFF
--- a/model/StardistSegmenter.py
+++ b/model/StardistSegmenter.py
@@ -30,7 +30,7 @@ from csbdeep.utils import normalize
 from skimage.io import imread
 from skimage.measure import regionprops
 from skimage.transform import resize
-from stardist.models import StarDist2D
+from stardist.models import model2d, StarDist2D
 
 # Local application imports
 from model.BaseModel import BaseModel
@@ -127,21 +127,20 @@ class StardistSegmenter(BaseModel):
        
         self.original_image = safegray2rgb(image)
         try:
-            import stardist.models.model2d
-            import numpy as np
-            original_nms = stardist.models.model2d.non_maximum_suppression_sparse
+            #import stardist.models.model2d
+            original_nms = model2d.non_maximum_suppression_sparse
             def safe_nms_sparse(dist, prob, points, *args, **kwargs):
                 # Clip distances to prevent C++ NMS crash on extreme values (e.g. >1e22)
                 dist = np.clip(dist, a_min=None, a_max=10000.0)
                 return original_nms(dist, prob, points, *args, **kwargs)
             
-            stardist.models.model2d.non_maximum_suppression_sparse = safe_nms_sparse
+            model2d.non_maximum_suppression_sparse = safe_nms_sparse
             
             labels, details = None, None
             try:
                 labels, details = self.model.predict_instances(img_inference)
             finally:
-                stardist.models.model2d.non_maximum_suppression_sparse = original_nms
+                model2d.non_maximum_suppression_sparse = original_nms
 
             self.detections = self.stardist_results_to_pandas(
                 labels,

--- a/model/StardistSegmenter.py
+++ b/model/StardistSegmenter.py
@@ -127,7 +127,6 @@ class StardistSegmenter(BaseModel):
        
         self.original_image = safegray2rgb(image)
         try:
-            #import stardist.models.model2d
             original_nms = model2d.non_maximum_suppression_sparse
             def safe_nms_sparse(dist, prob, points, *args, **kwargs):
                 # Clip distances to prevent C++ NMS crash on extreme values (e.g. >1e22)

--- a/model/StardistSegmenter.py
+++ b/model/StardistSegmenter.py
@@ -127,8 +127,22 @@ class StardistSegmenter(BaseModel):
        
         self.original_image = safegray2rgb(image)
         try:
+            import stardist.models.model2d
+            import numpy as np
+            original_nms = stardist.models.model2d.non_maximum_suppression_sparse
+            def safe_nms_sparse(dist, prob, points, *args, **kwargs):
+                # Clip distances to prevent C++ NMS crash on extreme values (e.g. >1e22)
+                dist = np.clip(dist, a_min=None, a_max=10000.0)
+                return original_nms(dist, prob, points, *args, **kwargs)
+            
+            stardist.models.model2d.non_maximum_suppression_sparse = safe_nms_sparse
+            
             labels, details = None, None
-            labels, details = self.model.predict_instances(img_inference)
+            try:
+                labels, details = self.model.predict_instances(img_inference)
+            finally:
+                stardist.models.model2d.non_maximum_suppression_sparse = original_nms
+
             self.detections = self.stardist_results_to_pandas(
                 labels,
                 scores=details["prob"],

--- a/tests/unittests/test_runtime_regressions.py
+++ b/tests/unittests/test_runtime_regressions.py
@@ -99,6 +99,9 @@ def _fake_stardist_modules():
             super().__init__("stardist")
             self.models = types.SimpleNamespace()
             self.models.StarDist2D = _FakeStarDist2D
+            self.models.model2d = types.SimpleNamespace(
+                non_maximum_suppression_sparse=lambda *args, **kwargs: None
+            )
 
     fake_tf = FakeTf()
     fake_stardist = FakeStardist()
@@ -107,6 +110,7 @@ def _fake_stardist_modules():
         "tensorflow": fake_tf,
         "stardist": fake_stardist,
         "stardist.models": fake_stardist.models,
+        "stardist.models.model2d": fake_stardist.models.model2d,
     }
 
 


### PR DESCRIPTION
# Fix for StarDist Segmenter Fatal Python Error

## The Issue
When running the automated testing suite on the Windows environment (run_all_tests.bat), the script tests_local/test_smoke.py::test_smoke[StarDist-testimages/Stained Nuclei Images/A1_1.TIF] consistently caused a Fatal Python error: Aborted which crashed the entire test session. 

The stack trace mistakenly identified torch_python.dll as the failure point, but this was a red herring. PyTorch installs a generic signal handler (c10/util/AbortHandler.h) which aggressively catches any underlying C++ segfault or abort inside the process.

## Root Cause Analysis
Through detailed debugging, we isolated the issue directly to the stardist0602 custom-trained model acting on the specific image A1_1.TIF:
1. During inference on A1_1.TIF, the neural network outputted highly erratic polygonal coordinate distances (dist).
2. Specifically, the network predicted ray distances for certain "polygons" to be as large as `2.922198e+22` pixels.
3. When these massive numbers were fed into StarDist's native Windows C++ extension (stardist2d.cp311-win_amd64.pyd) for Non-Maximum Suppression (NMS), the float32 intersection calculations suffered from catastrophic integer/floating-point overflows and NaN propagation.
4. The C++ standard library immediately called std::abort() due to memory safety violations/overflow, which was then caught by PyTorch's crash handler.

## The Solution

Since legitimate predicted cells or nuclei in microscopy images should never have a polygonal radius exceeding thousands of pixels, we safely neutralized the issue at the Python layer before the native code was invoked.

### Changes Made
- Modified model/StardistSegmenter.py to dynamically monkey-patch the NMS function stardist.models.model2d.non_maximum_suppression_sparse.
- Added np.clip(dist, a_min=None, a_max=10000.0) as a middleware interceptor immediately before the native inference step.
- This safely clamps any astronomical distances down to a maximum of 10,000 pixels without altering valid detections, entirely bypassing the C++ integer overflow threshold.
- The try/finally block restores the original NMS logic cleanly after predictions are extracted.